### PR TITLE
Fix tracking current health

### DIFF
--- a/SynthRidersWebsockets/Harmony/RuntimePatch.cs
+++ b/SynthRidersWebsockets/Harmony/RuntimePatch.cs
@@ -53,3 +53,15 @@ public class GameControlManagerReturnToMenuPatch
         SynthRidersWebsockets.WebsocketMod.Instance.EmitReturnToMenuEvent();
     }
 }
+
+// For capturing the player's current health, as the original LifeBarHelper.GetScalePercent()
+// doesn't seem to return the correct value anymore (always zero)
+[HarmonyPatch(typeof(Game_ScoreManager), "UpdateHealthBar")]
+public class GameScoreManagerUpdateHealthBarPatch
+{
+    [HarmonyPostfix]
+    public static void PostFix(float health)
+    {
+        SynthRidersWebsockets.WebsocketMod.Instance.UpdateHealth(health);
+    }
+}

--- a/SynthRidersWebsockets/WebsocketMod.cs
+++ b/SynthRidersWebsockets/WebsocketMod.cs
@@ -50,6 +50,7 @@ namespace SynthRidersWebsockets
          */
         private float lastPlayTimeEventMS = 0;
         private float currentPlayTimeMS = 0.0f;
+        private float healthPercent = 1.0f;
 
         public override void OnInitializeMelon() {
             Instance = this;
@@ -266,13 +267,13 @@ namespace SynthRidersWebsockets
                 LoggerInstance.Msg("Null score manager, skipping OnNoteHit");
                 return;
             }
-            
+
             EventDataNoteHit noteHitEvent = new EventDataNoteHit(
                 score.Score,
                 score.CurrentCombo,
                 score.NotesCompleted,
                 score.TotalMultiplier,
-                LifeBarHelper.GetScalePercent(),
+                this.healthPercent,
                 currentPlayTimeMS
             );
 
@@ -283,7 +284,7 @@ namespace SynthRidersWebsockets
         {
             EventDataNoteMiss noteMissEvent = new EventDataNoteMiss(
                 GameControlManager.s_instance.ScoreManager.TotalMultiplier,
-                LifeBarHelper.GetScalePercent(),
+                this.healthPercent,
                 currentPlayTimeMS
             );
 
@@ -303,6 +304,21 @@ namespace SynthRidersWebsockets
         private void OnFailSpecial()
         {
             Send(new SynthRidersEvent<object>("FailSpecial", new object()));
+        }
+
+        public void UpdateHealth(float health)
+        {
+            // Because the game might return a number greater than one (sometimes ex: 1.0004172),
+            // We cap it at 1 for 100%.
+            if (health > 1.0) {
+                this.healthPercent = 1;
+            } else if (health < 0.0)
+            {
+                this.healthPercent = 0;
+            } else
+            {
+                this.healthPercent = health;
+            }
         }
 
         public  void Send<T>(SynthRidersEvent<T> outputEvent)


### PR DESCRIPTION
Health was being reported as always zero when it wasn't the case. (Apparently LifeBarHelper isn't functioning as expected anymore).  This corrects it to use UpdateHealthBar() instead to capture the info.
